### PR TITLE
chore: bump design-system to 1.4.7 (fix INVA form submission)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "prettier": "@aplinkosministerija/biip-prettier-config",
   "dependencies": {
-    "@aplinkosministerija/design-system": "^1.3.16",
+    "@aplinkosministerija/design-system": "^1.4.7",
     "@material-ui/core": "^4.12.4",
     "@reduxjs/toolkit": "^1.8.1",
     "@sentry/react": "^7.61.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,10 +67,10 @@
   resolved "https://registry.yarnpkg.com/@aplinkosministerija/biip-prettier-config/-/biip-prettier-config-1.1.0.tgz#f62b0dde76107ab3f646cce2d54d02bd783ce388"
   integrity sha512-DxWGfBY2KuK8OgP2KUb96ieGlqE5gYuxI22Yt1FfoIldlDENW5I8kXj+YFB4iG65i7e1neXPZd9RGHmxxDxxSQ==
 
-"@aplinkosministerija/design-system@^1.3.16":
-  version "1.3.16"
-  resolved "https://registry.yarnpkg.com/@aplinkosministerija/design-system/-/design-system-1.3.16.tgz#10883bc586b395c22b349a9faf336f67e8872d6d"
-  integrity sha512-Intz0cemi2hPd9MtWzP1dGRy1c825+gitzn4ar8um0SPBqJHT46rPgiO7AVb3NZkFqujyCbfmHt1u2xE0h/Rew==
+"@aplinkosministerija/design-system@^1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@aplinkosministerija/design-system/-/design-system-1.4.7.tgz#04fb8d88adacbdcf47c619803f8352916277d723"
+  integrity sha512-fGbp0H6jiXwp8QRt7ntsUgDAuHxv2NmhS+LWnefVbIL1j2lhOlpz/7jZbTB1Wz3NQFzwTxNXcZIXFnmNVSHKmQ==
   dependencies:
     "@mapbox/mapbox-gl-draw" "^1.4.3"
     "@mapbox/mapbox-gl-draw-static-mode" "^1.0.1"


### PR DESCRIPTION
## Summary
- Bumps `@aplinkosministerija/design-system` from `^1.3.16` → `^1.4.7`.
- Picks up [AplinkosMinisterija/design-system#266](https://github.com/AplinkosMinisterija/design-system/pull/266) — `MapField` no longer silently drops the user's geometry when the boundaries municipality lookup fails (e.g. PostGIS rejects an invalid/self-intersecting polygon, 5xx, network error).

## Context
On INVA observation / request forms, pasting a long polygon coordinate list draws the polygon, but submission fails with *"Privalote pasirinkti vietą žemėlapyje"*. Root cause was the silent error in `MapField.handleSaveGeom` — see the upstream PR for the full write-up. `biip-admin-web` is unaffected because it uses its own local `DrawMap` widget without the boundaries call.

## Test plan
- [ ] `yarn install` succeeds; `yarn build` succeeds.
- [ ] Open the INVA observation form, paste a long polygon coordinate list with backtracking points (the original report's coordinates), draw polygon, submit — form should accept the submission instead of showing "Privalote pasirinkti vietą žemėlapyje". A `console.error("Failed to verify geometry against municipalities", …)` is expected in DevTools.
- [ ] Paste a simple in-Lithuania polygon — submits normally with no console error.
- [ ] Paste an out-of-Lithuania polygon — the "Pasirinkta geometrija nėra Lietuvos teritorijoje" alert still fires and submission is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)