### PR TITLE
fix(security): stop leaking and remotely invalidating the map token

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -2,6 +2,19 @@
 	root * /srv
 	encode gzip
 
+	header {
+		# This app is never embedded — it embeds the map, not the other way
+		# round (no window.parent / window.top usage anywhere in src/).
+		# Without a framing policy an attacker page could frame us and
+		# postMessage into the map-token handler in DisplayMap.tsx.
+		# frame-ancestors covers modern browsers, X-Frame-Options the rest.
+		Content-Security-Policy "frame-ancestors 'none'"
+		X-Frame-Options "DENY"
+
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+	}
+
 	try_files {path} {file} /index.html
 	file_server
 }

--- a/src/components/map/DisplayMap.tsx
+++ b/src/components/map/DisplayMap.tsx
@@ -1,7 +1,7 @@
 import { type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FeatureCollection } from '@aplinkosministerija/design-system';
 import { ButtonVariants } from '../../styles';
-import { Url } from '../../utils/constants';
+import { mapsOrigin, Url } from '../../utils/constants';
 import { useMapToken } from '../../utils/hooks';
 import LoaderComponent from '../other/LoaderComponent';
 import {
@@ -80,7 +80,9 @@ const DisplayMap = ({
   const handleLoadMap = () => {
     setLoading(false);
     if (geom) {
-      iframeRef?.current?.contentWindow?.postMessage({ geom }, '*');
+      // geom is a protected-species location — address the frame explicitly
+      // so it is not delivered to whatever origin the frame may hold later.
+      iframeRef?.current?.contentWindow?.postMessage({ geom }, mapsOrigin);
     }
   };
 
@@ -92,7 +94,7 @@ const DisplayMap = ({
         eventName: 'filterFeatures',
         places,
       }),
-      '*',
+      mapsOrigin,
     );
   }, [iframeRef, places]);
 
@@ -105,6 +107,12 @@ const DisplayMap = ({
 
   const handleMapAuthMessage = useCallback(
     async (event: MessageEvent<MapAuthMessageData>) => {
+      // Only the map iframe may tell us the token is dead. Without this any
+      // page that frames us (there is no frame-ancestors policy) could
+      // postMessage `{ auth: { valid: false } }` in a loop and keep deleting
+      // the map token, silently degrading the map to the public view.
+      if (!mapsOrigin || event.origin !== mapsOrigin) return;
+
       const isValidToken = event?.data?.mapIframeMsg?.auth?.valid;
 
       if (isValidToken === false) {
@@ -145,7 +153,8 @@ const DisplayMap = ({
             </StyledIconContainer>
           </StyledButton>
           <StyledIframe
-            allow="geolocation *"
+            allow={`geolocation ${mapsOrigin}`}
+            referrerPolicy="no-referrer"
             title="Radaviečių žemėlapis"
             ref={iframeRef}
             src={mapSrc}

--- a/src/pages/ObservationForm/components/ObservationMapContainer.tsx
+++ b/src/pages/ObservationForm/components/ObservationMapContainer.tsx
@@ -2,7 +2,7 @@ import { MapField } from '@aplinkosministerija/design-system';
 import { useState } from 'react';
 import SimpleContainer from '../../../components/containers/SimpleContainer';
 import DisplayMap from '../../../components/map/DisplayMap';
-import { mapsHost } from '../../../utils/constants';
+import { mapsHost, mapsOrigin } from '../../../utils/constants';
 import { formLabels } from '../../../utils/texts';
 import { FormProps, ObservationFormErrors } from '../types';
 import { ToggleBtn } from './ToggleButton';
@@ -49,7 +49,7 @@ export const ObservationMapContainer = ({
         <DisplayMap height="300px" geom={values?.geom} speciesId={speciesId} showAmateur={false} />
       ) : (
         <MapField
-          allow="geolocation *"
+          allow={`geolocation ${mapsOrigin}`}
           mapHost={mapsHost}
           value={geom}
           mapPath={mapQueryString}

--- a/src/pages/ObservationForm/functions.ts
+++ b/src/pages/ObservationForm/functions.ts
@@ -50,13 +50,15 @@ export const getAnimalEvolutionOptions = (activity?: AnimalActivity) =>
     return false;
   });
 
-export const getMapPath = (disabled = false, authToken?: string) => {
+// No `auth` param: the /edit route does not read one (it whitelists multi,
+// buffer, preview, hideToolbar, types, autoZoom, bufferMin, bufferMax,
+// closeOnSearch and showArea), so appending the 24h map JWT only put a bearer
+// credential for protected-species coordinates into the map host's access
+// logs, any URL-recording intermediary, and iframe.src in the DOM — where any
+// script on the page can read it.
+export const getMapPath = (disabled = false) => {
   const param = new URLSearchParams();
   const path = '/edit';
-
-  if (authToken) {
-    param.append('auth', authToken);
-  }
 
   if (disabled) {
     param.append('preview', 'true');

--- a/src/pages/ObservationForm/hooks/useData.ts
+++ b/src/pages/ObservationForm/hooks/useData.ts
@@ -2,7 +2,6 @@ import { isEmpty } from 'lodash';
 import { useMutation, useQuery } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import { DeleteInfoProps } from '../../../types';
-import { useMapToken } from '../../../utils/hooks';
 import {
   buttonsTitles,
   deleteDescriptionFirstPart,
@@ -21,7 +20,6 @@ export const useData = () => {
   const navigate = useNavigate();
   const { id = '' } = useParams();
   const { specie, specieLoading } = useGetSpecie(id);
-  const { mapToken } = useMapToken();
 
   const { data: observationForm, isFetching } = useQuery(
     ['form', id],
@@ -57,7 +55,7 @@ export const useData = () => {
 
   const disabled = !!observationForm && !observationForm?.canEdit;
 
-  const mapQueryString = getMapPath(disabled, mapToken);
+  const mapQueryString = getMapPath(disabled);
 
   const formMutation = useMutation(
     (values: FormServerProps) =>

--- a/src/pages/RequestForm/components/TaxonomiesContainer.tsx
+++ b/src/pages/RequestForm/components/TaxonomiesContainer.tsx
@@ -2,7 +2,7 @@ import { MapField } from '@aplinkosministerija/design-system';
 import { isEmpty, isEqual } from 'lodash';
 import SimpleContainer from '../../../components/containers/SimpleContainer';
 import Tree from '../../../components/fields/TreeSelect';
-import { mapsHost, RequestTypes } from '../../../utils/constants';
+import { mapsHost, mapsOrigin, RequestTypes } from '../../../utils/constants';
 import { inputLabels } from '../../../utils/texts';
 import { getMapPath } from '../function';
 import { useSpeciesTree } from '../hooks/useSpeciesTree';
@@ -43,7 +43,7 @@ const SpeciesTaxonomiesContainer = ({
           )}
           {!isEqual(values.type, RequestTypes.CHECK) && (
             <MapField
-              allow="geolocation *"
+              allow={`geolocation ${mapsOrigin}`}
               mapHost={mapsHost}
               value={values?.geom}
               mapPath={mapPath}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -235,6 +235,20 @@ export const Url = {
   SPECIES: `${mapsHost}/rusys`,
 };
 
+// Single source of truth for the map iframe's origin. Use it to validate
+// inbound `message` events and as the targetOrigin of every outbound
+// postMessage — never '*', because the payloads carry protected-species
+// geometry and the inbound ones can invalidate the map token.
+// Empty string when VITE_MAPS_HOST is unset or malformed, which makes the
+// comparison fail closed rather than accepting any origin.
+export const mapsOrigin = (() => {
+  try {
+    return new URL(mapsHost).origin;
+  } catch {
+    return '';
+  }
+})();
+
 export enum FormTypes {
   ENDANGERED_ANIMAL = 'ENDANGERED_ANIMAL',
   ENDANGERED_PLANT = 'ENDANGERED_PLANT',


### PR DESCRIPTION
Both issues are live on main, introduced/restructured by PR #82 (BSP-37). mapToken is a 24h JWT that authenticates the private SRIS layer — a bearer credential for protected species-occurrence coordinates.

DisplayMap.tsx — the `message` listener had no origin check, so any page that frames us could postMessage `{ mapIframeMsg: { auth: { valid: false } } }` in a loop and keep deleting the map token; the map then silently degrades to the public unauthenticated view and /maps/auth gets re-hit. (The 30s cooldown added earlier throttles the amplitude but does not stop it.) The design-system MapField already validates `event.origin === mapHost` — do the same here.

getMapPath / useData.ts — dropped the `auth` param from the /edit iframe URL. The /edit route never reads it (it whitelists multi, buffer, preview, hideToolbar, types, autoZoom, bufferMin, bufferMax, closeOnSearch, showArea — the only query.auth consumer in the map app is the rusys route), so appending the JWT put a live credential into the map host's access logs, any URL-recording intermediary, and iframe.src in the DOM for zero functional benefit. useMapToken() is no longer needed in useData at all — DisplayMap fetches the token where it is actually used.

Also in the same blast radius:

- postMessage targetOrigin is now mapsOrigin instead of '*', for both the geom payload (a protected-species location) and filterFeatures. With '*' the payload goes to whatever origin the frame currently holds.

- `allow="geolocation *"` delegated geolocation to every origin the frame might navigate to, in all three iframes (DisplayMap, ObservationMapContainer, TaxonomiesContainer). Scoped to the map origin.

- Added `referrerPolicy="no-referrer"` on the species map iframe.

- caddy/Caddyfile served no security headers at all, which is what made the postMessage attack above reachable. Added `frame-ancestors 'none'` plus X-Frame-Options: DENY (the app is never embedded — there is no window.parent/window.top usage in src/), X-Content-Type-Options and Referrer-Policy. Deliberately no script/style CSP directives here; that needs its own pass against styled-components.

New `mapsOrigin` export in constants.ts is the single source of truth, derived from VITE_MAPS_HOST and empty on a malformed value so the origin comparison fails closed.


Claude-Session: https://claude.ai/code/session_01PzcTVhzvLVjBrTUoWNiP2B